### PR TITLE
Fix for Tutorials table of contents and notebook content.

### DIFF
--- a/pages/get-started-guide.rst
+++ b/pages/get-started-guide.rst
@@ -23,7 +23,6 @@ Get Started
    :hidden:
    :caption: Get Started Guides
 
-   Interactive Tutorials (Python) <../tutorials>
    ./get-started-guide/samples
 
 .. raw:: html

--- a/tutorials.rst
+++ b/tutorials.rst
@@ -13,9 +13,10 @@ Tutorials
    :maxdepth: 2
    :caption: Notebooks
    :hidden:
+   :glob:
 
    notebooks-installation
-
+   notebooks/*
 
 This collection of Python tutorials are written for running on Jupyter notebooks. 
 The tutorials provide an introduction to the OpenVINO™ toolkit and explain how to 


### PR DESCRIPTION
1. Removed tutorials.rst from get-started-guide.rst toc.
   This was causing the issue where the get started guide
   table of contents was showing up on the tutorials page.
2. Added :glob: parameter and notebooks/* to tutorials.rst toc.
   This adds all of the notebooks to the tutorials table of contents.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>