### PR TITLE
Fixes missing ecosystem docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ open_model_zoo
 models
 demos
 old_pages
+pages/documentation/ecosystem

--- a/get_ecosystem_docs.sh
+++ b/get_ecosystem_docs.sh
@@ -1,0 +1,12 @@
+rm -rf pages/documentation/ecosystem
+git clone git@github.com:openvinotoolkit/model_server.git
+git clone git@github.com:openvinotoolkit/openvino_tensorflow.git
+git clone git@github.com:openvinotoolkit/training_extensions.git
+mkdir pages/documentation/ecosystem
+mkdir pages/documentation/ecosystem/model-server
+cp -rf model_server/docs/* pages/documentation/ecosystem/model-server
+cp openvino_tensorflow/README.md pages/documentation/ecosystem/openvino-tensorflow-integration.md
+cp training_extensions/OTE_landing_page.md pages/documentation/ecosystem
+rm -rf model_server
+rm -rf openvino_tensorflow
+rm -rf training_extensions

--- a/pages/documentation.rst
+++ b/pages/documentation.rst
@@ -58,11 +58,11 @@ Documentation
    :hidden:
    :caption: THE Ecosystem
 
-   openvino_ecosystem
-   ovms_what_is_openvino_model_server
+   documentation/openvino_ecosystem
+   documentation/ecosystem/model-server/home
    ./documentation/openvino-security-add-on
-   ovtf_integration
-   ote_documentation
+   documentation/ecosystem/openvino-tensorflow-integration
+   documentation/ecosystem/OTE_landing_page
    ./documentation/dl-workbench-overview
 
 

--- a/pages/documentation/openvino_ecosystem.rst
+++ b/pages/documentation/openvino_ecosystem.rst
@@ -1,0 +1,124 @@
+.. index:: pair: page; OpenVINO™ Ecosystem Overview
+.. _doxid-openvino_ecosystem:
+
+
+OpenVINO™ Ecosystem Overview
+==============================
+
+:target:`doxid-openvino_ecosystem_1md_openvino_docs_documentation_openvino_ecosystem`
+
+OpenVINO™ is not just one tool. It is an expansive ecosystem of utilities, providing a comprehensive workflow for deep learning solution development. Learn more about each of them to reach the full potential of OpenVINO™ Toolkit.
+
+OpenVINO™ Model Server (OVMS)
+-------------------------------
+
+OpenVINO Model Server is a scalable, high-performance solution for serving deep learning models optimized for Intel® architectures. The server uses Inference Engine libraries as a backend and exposes gRPC and HTTP/REST interfaces for inference that are fully compatible with TensorFlow Serving.
+
+More resources:
+
+* `OpenVINO documentation <https://docs.openvino.ai/latest/openvino_docs_ovms.html>`__
+
+* `Docker Hub <https://hub.docker.com/r/openvino/model_server>`__
+
+* `GitHub <https://github.com/openvinotoolkit/model_server>`__
+
+* `Red Hat Ecosystem Catalog <https://catalog.redhat.com/software/container-stacks/detail/60649e41ccfb383fe395a167>`__
+
+Neural Network Compression Framework (NNCF)
+-------------------------------------------
+
+A suite of advanced algorithms for Neural Network inference optimization with minimal accuracy drop. NNCF applies quantization, filter pruning, binarization and sparsity algorithms to PyTorch and TensorFlow models during training.
+
+More resources:
+
+* :ref:`Documentation <doxid-docs_nncf_introduction>`
+
+* `GitHub <https://github.com/openvinotoolkit/nncf>`__
+
+* `PyPI <https://pypi.org/project/nncf/>`__
+
+OpenVINO™ Security Add-on
+---------------------------
+
+A solution for Model Developers and Independent Software Vendors to use secure packaging and secure model execution.
+
+More resources:
+
+* `documentation <https://docs.openvino.ai/latest/ovsa_get_started.html>`__
+
+* [GitHub] `https://github.com/openvinotoolkit/security_addon <https://github.com/openvinotoolkit/security_addon>`__)
+
+OpenVINO™ integration with TensorFlow (OVTF)
+----------------------------------------------
+
+A solution empowering TensorFlow developers with OpenVINO's optimization capabilities. With just two lines of code in your application, you can offload inference to OpenVINO, while keeping the TensorFlow API.
+
+More resources:
+
+* `documentation <https://github.com/openvinotoolkit/openvino_tensorflow>`__
+
+* `PyPI <https://pypi.org/project/openvino-tensorflow/>`__
+
+* `GitHub <https://github.com/openvinotoolkit/openvino_tensorflow>`__
+
+DL Streamer
+-----------
+
+A streaming media analytics framework, based on the GStreamer multimedia framework, for creating complex media analytics pipelines.
+
+More resources:
+
+* `documentation on GitHub <https://openvinotoolkit.github.io/dlstreamer_gst/>`__
+
+* `installation Guide on GitHub <https://github.com/openvinotoolkit/dlstreamer_gst/wiki/Install-Guide>`__
+
+DL Workbench
+------------
+
+A web-based tool for deploying deep learning models. Built on the core of OpenVINO and equipped with a graphics user interface, DL Workbench is a great way to explore the possibilities of the OpenVINO workflow, import, analyze, optimize, and build your pre-trained models. You can do all that by visiting `Intel® DevCloud for the Edge <https://software.intel.com/content/www/us/en/develop/tools/devcloud.html>`__ and launching DL Workbench on-line.
+
+More resources:
+
+* :ref:`documentation <doxid-workbench_docs__workbench__d_g__introduction>`
+
+* `Docker Hub <https://hub.docker.com/r/openvino/workbench>`__
+
+* `PyPI <https://pypi.org/project/openvino-workbench/>`__
+
+OpenVINO™ Training Extensions (OTE)
+-------------------------------------
+
+A convenient environment to train Deep Learning models and convert them using the OpenVINO™ toolkit for optimized inference.
+
+More resources:
+
+* `GitHub <https://github.com/openvinotoolkit/training_extensions>`__
+
+Computer Vision Annotation Tool (CVAT)
+--------------------------------------
+
+An online, interactive video and image annotation tool for computer vision purposes.
+
+More resources:
+
+* `documentation on GitHub <https://openvinotoolkit.github.io/cvat/docs/>`__
+
+* `web application <https://cvat.org/>`__
+
+* `Docker Hub <https://hub.docker.com/r/openvino/cvat_server>`__
+
+* `GitHub <https://github.com/openvinotoolkit/cvat>`__
+
+Dataset Management Framework (Datumaro)
+---------------------------------------
+
+A framework and CLI tool to build, transform, and analyze datasets.
+
+More resources:
+
+* `documentation on GitHub <https://openvinotoolkit.github.io/datumaro/docs/>`__
+
+* `PyPI <https://pypi.org/project/datumaro/>`__
+
+* `GitHub <https://github.com/openvinotoolkit/datumaro>`__
+


### PR DESCRIPTION
There are dependencies in other repos that need to be resolved for this to work as expected.

1. Adds ecosystem directory to the .gitignore since content is added via script
2. get_ecosystem_docs.sh clones and moves desired contents from model_server, openvino_tensorflow, and training_extensions repos
3. pages/documentation.rst - adds required entries to toctree
4. restores pages/documentation/openvino_ecosystem.rst that was missing.

Signed-off-by: Kevin Putnam <kevin.putnam@intel.com>