### PR TITLE
Port: Fix OpenVINO Extensibility

### DIFF
--- a/pages/documentation/openvino-extensibility-mechanism/model_optimizer_extensibility.rst
+++ b/pages/documentation/openvino-extensibility-mechanism/model_optimizer_extensibility.rst
@@ -82,7 +82,7 @@ and ``mo.graph.port.Port`` classes. Thus, low-level graph manipulation is error 
 
 Further details and examples related to a model representation in memory are provided in the sections below, 
 in a context for a better explanation. Also, for more information on how to use ports and connections, 
-refer to the `Graph Traversal and Modification Using s and s <#graph-ports-and-conneсtions>`__ section.
+refer to the `Graph Traversal and Modification Using Ports and Connections <#graph-ports>`__ section.
 
 .. _model-conversion-pipeline:
 
@@ -285,7 +285,7 @@ available in the ``mo/ops/reshape.py`` file):
 
 Methods ``in_port()`` and ``output_port()`` of the ``Node`` class are used to get and set data node attributes. For more 
 information on how to use them, refer to the 
-`Graph Traversal and Modification Using Ports and Connections <#graph-ports-and-conneсtions>`__ section.
+`Graph Traversal and Modification Using Ports and Connections <#graph-ports>`__ section.
 
 .. _middle-phase:
 
@@ -314,7 +314,7 @@ Middle Phase
 The middle phase starts after partial inference. At this phase, a graph contains data nodes and output shapes of all operations 
 in the graph have been calculated. Any transformation implemented at this stage must update the ``shape`` attribute for all 
 newly added operations. It is highly recommended to use API described in the 
-`Graph Traversal and Modification Using Ports and Connections <#graph-ports-and-conneсtions>`__ because modification of a graph 
+`Graph Traversal and Modification Using Ports and Connections <#graph-ports>`__ because modification of a graph 
 using this API causes automatic re-inference of affected nodes as well as necessary data nodes creation.
 
 More information on how to develop middle transformations and dedicated API description is provided in the 
@@ -385,7 +385,7 @@ The last phase of a model conversion is the Intermediate Representation emitting
 
 #. Generates an ``.xml`` file defining a graph structure. The information about operation inputs and outputs are prepared uniformly for all operations regardless of their type. A list of attributes to be saved to the ``.xml`` file is defined with the ``backend_attrs()`` or ``supported_attrs()`` of the ``Op`` class used for a graph node instantiation. For more information on how the operation attributes are saved to XML, refer to the function ``prepare_emit_ir()`` in the ``mo/pipeline/common.py`` file and `Model Optimizer Operation <#extension-operation>`__ section.
 
-.. _graph-ports-and-conneсtions:
+.. _graph-ports:
 
 Graph Traversal and Modification Using Ports and Connections
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/pages/documentation/openvino-plugin-developer-guide/executable-network-class-in-custom-plugins.rst
+++ b/pages/documentation/openvino-plugin-developer-guide/executable-network-class-in-custom-plugins.rst
@@ -383,7 +383,7 @@ network is compiled with.
 	}
 
 This function is the only way to get configuration values when a network is imported and compiled by other developers 
-and tools (for example, the `Compile tool <../_inference_engine_tools_compile_tool_README.html>`__).
+and tools (for example, the :ref:`Compile tool <deploy_infer__compile_tool>`).
 
 The next step in plugin library implementation is the 
 :ref:`Synchronous Inference Request <extensibility_plugin__synch_inf_req>` class.

--- a/pages/documentation/openvino-plugin-developer-guide/openvino-custom-plugins.rst
+++ b/pages/documentation/openvino-plugin-developer-guide/openvino-custom-plugins.rst
@@ -201,7 +201,7 @@ The function accepts a const shared pointer to ``:ref:`ov::Model <doxid-classov_
 
 #. Applies common and plugin-specific transformations on a copied graph to make the graph more friendly to hardware operations. For details how to write custom plugin-specific transformation, please, refer to :ref:`Writing OpenVINO™ transformations <extensibility_transformations__overview>` guide. See detailed topics about network representation:
    
-   * `Intermediate Representation and Operation Sets <../_docs_MO_DG_IR_and_opsets.html>`__
+   * :ref:`Intermediate Representation and Operation Sets <doxid-openvino_docs__m_o__d_g__i_r_and_opsets>`
    
    * :ref:`Quantized networks <extensibility_plugin__quantized_networks>`.
 

--- a/pages/documentation/openvino-transformation-api.rst
+++ b/pages/documentation/openvino-transformation-api.rst
@@ -165,7 +165,7 @@ To eliminate operation, OpenVINO™ has special method that considers all limita
 ``:ref:`ov::replace_output_update_name() <doxid-namespaceov_1a75ba2120e573883bd96bb19c887c6a1d>``` in case of successful 
 replacement it automatically preserves friendly name and runtime info.
 
-.. _transformations_types:
+.. _transformations-types:
 
 Transformations types
 ~~~~~~~~~~~~~~~~~~~~~
@@ -245,8 +245,9 @@ When transformation has multiple fusions or decompositions,
 ``:ref:`ov::copy_runtime_info <doxid-namespaceov_1a3bb5969a95703b4b4fd77f6f58837207>``` must be called multiple times 
 for each case.
 
-**Note** : copy_runtime_info removes rt_info from destination nodes. If you want to keep it, you need to specify them 
-in source nodes like this: copy_runtime_info({a, b, c}, {a, b})
+.. note:: 
+   `copy_runtime_info` removes `rt_info` from destination nodes. If you want to keep it, you need to specify them 
+   in source nodes like this: `copy_runtime_info({a, b, c}, {a, b})`
 
 3. Constant Folding
 -------------------
@@ -307,7 +308,7 @@ Using pass manager
 
 ``:ref:`ov::pass::Manager <doxid-classov_1_1pass_1_1_manager>``` is a container class that can store the list of transformations 
 and execute them. The main idea of this class is to have high-level representation for grouped list of transformations. It can 
-register and apply any `transformation pass <#transformations_types>`__ on model. In addition, 
+register and apply any `transformation pass <#transformations-types>`__ on model. In addition, 
 ``:ref:`ov::pass::Manager <doxid-classov_1_1pass_1_1_manager>``` has extended debug capabilities (find more information in 
 the `how to debug transformations <#how_to_debug_transformations>`__ section).
 


### PR DESCRIPTION
Fixed errors in OpenVINO Extensibility:

* Broken links,
* Broke notes directives,
* Bash commands,
* Not working ref links

Port from https://github.com/openvinotoolkit/openvino/pull/13108